### PR TITLE
Fix warning generated in Zookeeper log by monit check.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,5 @@ USER $SERVICE_USER
 WORKDIR $SERVICE_HOME
 
 EXPOSE 2181 2888 3888
+
+HEALTHCHECK CMD monit summary | grep Running | grep -q zk-service || exit 1

--- a/root/opt/monit/etc/conf.d/monit-service.conf
+++ b/root/opt/monit/etc/conf.d/monit-service.conf
@@ -1,6 +1,6 @@
 check process zk-service with pidfile /opt/zk/data/zookeeper_server.pid
   start program = "/opt/zk/bin/zk-service.sh start"
   stop program = "/opt/zk/bin/zk-service.sh stop"
-  if failed port 2181 type tcp for 5 cycles then exec "/opt/monit/bin/monit quit"
+  if failed port 2181 and send "ruok" expect "imok" for 5 cycles then exec "/opt/monit/bin/monit quit"
 
   


### PR DESCRIPTION
- modify to monit check to use custom protocl of checking state of Zookeeper
- add `HEALTHCHECK CMD` to Dockerfile